### PR TITLE
Use oblv-ctl 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ oblv-ctl>=0.3.0
 pydantic>=1.8.0,<2.0.0
 python-multipart==0.0.5
 PyYAML==6.0
-syft @ git+https://github.com/OpenMined/PySyft@oblv/0.8_refactor#egg=syft&subdirectory=packages/syft
+syft @ git+https://github.com/OpenMined/PySyft@dev#egg=syft&subdirectory=packages/syft
 uvicorn==0.21.1
 validators==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ oblv-ctl==0.3.1
 pydantic>=1.8.0,<2.0.0
 python-multipart==0.0.5
 PyYAML==6.0
-syft @ git+https://github.com/OpenMined/PySyft@dev#egg=syft&subdirectory=packages/syft
+syft @ git+https://github.com/yashgorana/PySyft@yash/oblv#egg=syft&subdirectory=packages/syft
 uvicorn==0.21.1
 validators==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.95.1
-oblv-ctl>=0.3.0
+oblv-ctl==0.3.1
 pydantic>=1.8.0,<2.0.0
 python-multipart==0.0.5
 PyYAML==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-fastapi>=0.68.0,<0.69.0
-pydantic>=1.8.0,<2.0.0
+fastapi==0.95.1
 oblv-ctl>=0.3.0
+pydantic>=1.8.0,<2.0.0
 python-multipart==0.0.5
 PyYAML==6.0
 syft @ git+https://github.com/OpenMined/PySyft@oblv/0.8_refactor#egg=syft&subdirectory=packages/syft
-uvicorn>=0.15.0,<0.16.0
+uvicorn==0.21.1
 validators==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.68.0,<0.69.0
 pydantic>=1.8.0,<2.0.0
-pyoblv>=0.2.0
+oblv-ctl>=0.3.0
 python-multipart==0.0.5
 PyYAML==6.0
 syft @ git+https://github.com/OpenMined/PySyft@oblv/0.8_refactor#egg=syft&subdirectory=packages/syft

--- a/src/app.py
+++ b/src/app.py
@@ -37,7 +37,7 @@ async def root():
 
 
 # Adding routes for each example in the repo
-app.include_router(worker.router)
+app.include_router(worker.router, prefix="/api/v1/new")
 
 # This is only here to customize the swagger :)
 def custom_openapi():

--- a/src/routes/worker.py
+++ b/src/routes/worker.py
@@ -1,40 +1,13 @@
 # stdlib
 import os
 
-from syft import Worker, deserialize, enable_external_lib, serialize
-from syft.client.client import Routes
-from syft.node.credentials import SyftVerifyKey
+from syft import Worker, enable_external_lib
 from syft.abstract_node import NodeType
+from syft.node.routes import make_routes
 
-from fastapi import APIRouter, Depends, Request, Response  # isort: skipAPIRoute
-
-
-router = APIRouter(tags=["worker"])
 enable_external_lib("oblv")
 os.environ["ENABLE_OBLV"] = "true"
 
-
 worker: Worker = Worker(node_type=NodeType.ENCLAVE)
 
-
-async def get_body(request: Request):
-    return await request.body()
-
-
-@router.post(f"{Routes.ROUTE_API_CALL.value}")
-def syft_api_call(data: bytes = Depends(get_body)) -> Response:
-    obj_msg = deserialize(blob=data, from_bytes=True)
-    result = worker.handle_api_call(api_call=obj_msg)
-    return Response(
-        serialize(result, to_bytes=True),
-        media_type="application/octet-stream",
-    )
-
-
-@router.get(f"{Routes.ROUTE_API.value}")
-def syft_new_api(verify_key: str) -> Response:
-    user_verify_key: SyftVerifyKey = SyftVerifyKey.from_string(verify_key)
-    return Response(
-        serialize(worker.get_api(user_verify_key), to_bytes=True),
-        media_type="application/octet-stream",
-    )
+router = make_routes(worker=worker)

--- a/src/routes/worker.py
+++ b/src/routes/worker.py
@@ -2,9 +2,9 @@
 import os
 
 from syft import Worker, deserialize, enable_external_lib, serialize
-from syft.core.node.new.client import Routes
-from syft.core.node.new.credentials import SyftVerifyKey
-from syft.core.node.worker import NodeType
+from syft.client.client import Routes
+from syft.node.credentials import SyftVerifyKey
+from syft.abstract_node import NodeType
 
 from fastapi import APIRouter, Depends, Request, Response  # isort: skipAPIRoute
 


### PR DESCRIPTION
## Description
Use the updated oblv-ctl package instead of pyoblv (which has been deprecated). Update the code to use syft 0.8.0-style imports.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
